### PR TITLE
Add zombienet config for rinzler

### DIFF
--- a/scripts/rinzler_zombienet_config.toml
+++ b/scripts/rinzler_zombienet_config.toml
@@ -1,0 +1,21 @@
+[relaychain]
+default_command = "./bin/polkadot-v0.9.32"
+default_args = [ "-lparachain=debug" ]
+
+chain = "rococo-local"
+  [[relaychain.nodes]]
+  name = "alice"
+  validator = true
+
+  [[relaychain.nodes]]
+  name = "bob"
+  validator = true
+
+[[parachains]]
+id = 1000
+cumulus_based = true
+chain = "dev"
+
+  [parachains.collator]
+  name = "rinzler-collator-01"
+  command = "./paratensor"


### PR DESCRIPTION
Add a config which allows zombienet to be used with paratensor. Launches two relay validators and a single parachain collator. Zombienet handles registering parachains and all other initial setup on boot.

Run zombienet with these arguments:
`./zombienet-linux-x64 --provider native spawn scripts/rinzler_zombienet_config.toml`

@eduardogr @unconst 